### PR TITLE
fix: always treat autocorrect as attribute

### DIFF
--- a/packages/runtime-dom/src/patchProp.ts
+++ b/packages/runtime-dom/src/patchProp.ts
@@ -102,7 +102,7 @@ function shouldSetAsProp(
   // them as attributes.
   // Note that `contentEditable` doesn't have this problem: its DOM
   // property is also enumerated string values.
-  if (key === 'spellcheck' || key === 'draggable' || key === 'translate') {
+  if (key === 'spellcheck' || key === 'draggable' || key === 'translate' || key === 'autocorrect') {
     return false
   }
 


### PR DESCRIPTION
Fix #5705

As the [WebKit](https://bugs.webkit.org/show_bug.cgi?id=289197) devs said, this issue is currently only really visible on iOS, but it should also happen on Firefox and most likely on Chrome too.